### PR TITLE
Fix to prevent displaying a previous frame.

### DIFF
--- a/code/rd-vanilla/tr_WorldEffects.cpp
+++ b/code/rd-vanilla/tr_WorldEffects.cpp
@@ -1550,6 +1550,7 @@ public:
 			}
 		}
 		qglEnd();
+		backEnd.needPresent = qtrue;
 
 		qglEnable(GL_CULL_FACE);
 		qglPopMatrix();

--- a/code/rd-vanilla/tr_backend.cpp
+++ b/code/rd-vanilla/tr_backend.cpp
@@ -415,6 +415,7 @@ static void RB_Hyperspace( void ) {
 	c = ( backEnd.refdef.time & 255 ) / 255.0f;
 	qglClearColor( c, c, c, 1 );
 	qglClear( GL_COLOR_BUFFER_BIT );
+	backEnd.needPresent = qtrue;
 
 	backEnd.isHyperspace = qtrue;
 }
@@ -528,6 +529,7 @@ static void RB_BeginDrawingView (void) {
 	if (clearBits)
 	{
 		qglClear( clearBits );
+		backEnd.needPresent = qtrue;
 	}
 
 	if ( ( backEnd.refdef.rdflags & RDF_HYPERSPACE ) )
@@ -1415,6 +1417,7 @@ const void	*RB_DrawBuffer( const void *data ) {
 
 		qglClearColor(fog->parms.color[0],  fog->parms.color[1], fog->parms.color[2], 1.0f );
 		qglClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+		backEnd.needPresent = qtrue;
 	}
 	else if (!( backEnd.refdef.rdflags & RDF_NOWORLDMODEL ) && tr.world && tr.world->globalFog != -1 && tr.sceneCount)//don't clear during menus, wait for real scene
 	{
@@ -1422,6 +1425,7 @@ const void	*RB_DrawBuffer( const void *data ) {
 
 		qglClearColor(fog->parms.color[0],  fog->parms.color[1], fog->parms.color[2], 1.0f );
 		qglClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
+		backEnd.needPresent = qtrue;
 	}
 	else if ( r_clear->integer )
 	{	// clear screen for debugging
@@ -1460,6 +1464,7 @@ const void	*RB_DrawBuffer( const void *data ) {
 			break;
 		}
 		qglClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
+		backEnd.needPresent = qtrue;
 	}
 
 	return (const void *)(cmd + 1);
@@ -1516,6 +1521,7 @@ void RB_ShowImages( void ) {
 			qglVertex2f( x, y + h );
 		qglEnd();
 		i++;
+		backEnd.needPresent = qtrue;
 	}
 
 	qglFinish();
@@ -1571,7 +1577,11 @@ const void	*RB_SwapBuffers( const void *data ) {
 
     GLimp_LogComment( "***************** RB_SwapBuffers *****************\n\n\n" );
 
-	ri.WIN_Present(&window);
+	if (backEnd.needPresent)
+	{
+		ri.WIN_Present(&window);
+		backEnd.needPresent = qfalse;
+	}
 
 	backEnd.projection2D = qfalse;
 

--- a/code/rd-vanilla/tr_draw.cpp
+++ b/code/rd-vanilla/tr_draw.cpp
@@ -136,6 +136,7 @@ void RE_StretchRaw (int x, int y, int w, int h, int cols, int rows, const byte *
 	qglTexCoord2f ( 0.5f / cols, ( rows - 0.5f ) / rows );
 	qglVertex2f (x, y+h);
 	qglEnd ();
+	backEnd.needPresent = qtrue;
 }
 
 
@@ -454,6 +455,7 @@ static void RE_Blit(float fX0, float fY0, float fX1, float fY1, float fX2, float
 		qglVertex2f( fX3, fY3);
 	}
 	qglEnd ();
+	backEnd.needPresent = qtrue;
 }
 
 static void RE_KillDissolve(void)

--- a/code/rd-vanilla/tr_local.h
+++ b/code/rd-vanilla/tr_local.h
@@ -942,6 +942,8 @@ typedef struct {
 	byte		color2D[4];
 	qboolean	vertexes2D;		// shader needs to be finished
 	trRefEntity_t	entity2D;	// currentEntity will point at this when doing 2D rendering
+
+	qboolean	needPresent;
 } backEndState_t;
 
 /*

--- a/code/rd-vanilla/tr_main.cpp
+++ b/code/rd-vanilla/tr_main.cpp
@@ -1423,6 +1423,8 @@ void R_DebugPolygon( int color, int numPoints, float *points ) {
 	}
 	qglEnd();
 	qglDepthRange( 0, 1 );
+
+	backEnd.needPresent = qtrue;
 }
 
 /*

--- a/code/rd-vanilla/tr_quicksprite.cpp
+++ b/code/rd-vanilla/tr_quicksprite.cpp
@@ -119,6 +119,7 @@ void CQuickSpriteSystem::Flush(void)
 	}
 
 	qglDrawArrays(GL_QUADS, 0, mNextVert);
+	backEnd.needPresent = qtrue;
 
 	backEnd.pc.c_vertexes += mNextVert;
 	backEnd.pc.c_indexes += mNextVert;
@@ -151,6 +152,7 @@ void CQuickSpriteSystem::Flush(void)
 //		qglVertexPointer (3, GL_FLOAT, 16, mVerts);	// Done above
 
 		qglDrawArrays(GL_QUADS, 0, mNextVert);
+		backEnd.needPresent = qtrue;
 
 		// Second pass from fog
 		backEnd.pc.c_totalIndexes += mNextVert;

--- a/code/rd-vanilla/tr_shade.cpp
+++ b/code/rd-vanilla/tr_shade.cpp
@@ -159,6 +159,7 @@ static void R_DrawStripElements( int numIndexes, const glIndex_t *indexes, void 
 	}
 
 	qglEnd();
+	backEnd.needPresent = qtrue;
 }
 
 /*
@@ -190,6 +191,7 @@ static void R_DrawElements( int numIndexes, const glIndex_t *indexes ) {
 						numIndexes,
 						GL_INDEX_TYPE,
 						indexes );
+		backEnd.needPresent = qtrue;
 		return;
 	}
 
@@ -410,6 +412,8 @@ static void DrawNormals (shaderCommands_t *input) {
 	qglEnd ();
 
 	qglDepthRange( 0, 1 );
+
+	backEnd.needPresent = qtrue;
 }
 
 

--- a/code/rd-vanilla/tr_shadows.cpp
+++ b/code/rd-vanilla/tr_shadows.cpp
@@ -132,6 +132,7 @@ void R_RenderShadowEdges( void ) {
 				c_rejected++;
 			}
 #endif
+			backEnd.needPresent = qtrue;
 		}
 	}
 
@@ -161,6 +162,7 @@ void R_RenderShadowEdges( void ) {
 			qglVertex3fv(shadowXyz[o2]);
 			qglVertex3fv(shadowXyz[o1]);
 		qglEnd();
+		backEnd.needPresent = qtrue;
 	}
 #endif
 }
@@ -468,6 +470,7 @@ void RB_ShadowFinish( void ) {
 	qglVertex3f( 100, -100, -10 );
 	qglVertex3f( -100, -100, -10 );
 	qglEnd ();
+	backEnd.needPresent = qtrue;
 
 	qglColor4f(1,1,1,1);
 	qglDisable( GL_STENCIL_TEST );
@@ -673,6 +676,7 @@ void RB_DistortionFill(void)
 		qglTexCoord2f(1-spost2, 1-spost);
 		qglVertex2f(glConfig.vidWidth, 0);
 	qglEnd();
+	backEnd.needPresent = qtrue;
 
 	if (tr_distortionAlpha == 1.0f && tr_distortionStretch == 0.0f)
 	{ //no overrides
@@ -715,6 +719,7 @@ void RB_DistortionFill(void)
 			qglTexCoord2f(1-spost2, 1-spost);
 			qglVertex2f(glConfig.vidWidth, 0);
 		qglEnd();
+		backEnd.needPresent = qtrue;
 	}
 
 	//pop the view matrices back

--- a/code/rd-vanilla/tr_sky.cpp
+++ b/code/rd-vanilla/tr_sky.cpp
@@ -386,6 +386,7 @@ static void DrawSkySide( struct image_s *image, const int mins[2], const int max
 		}
 
 		qglEnd();
+		backEnd.needPresent = qtrue;
 	}
 }
 

--- a/code/rd-vanilla/tr_surface.cpp
+++ b/code/rd-vanilla/tr_surface.cpp
@@ -1116,6 +1116,7 @@ static void RB_SurfaceBeam( void )
 		qglVertex3fv( end_points[ i % NUM_BEAM_SEGS] );
 	}
 	qglEnd();
+	backEnd.needPresent = qtrue;
 }
 
 
@@ -1940,6 +1941,7 @@ static void RB_SurfaceAxis( void ) {
 	qglVertex3f( 0,0,16 );
 	qglEnd();
 	qglLineWidth( 1 );
+	backEnd.needPresent = qtrue;
 }
 
 //===========================================================================


### PR DESCRIPTION
For a brief moment an old frame is shown. This occurs because nothing is
drawn to the screen but a SwapBuffer (WIN_Present) is still done.

It's a bug that is hard to notice, only known occurance (but it could
happen elsewhere) is at the end of the load screen.
